### PR TITLE
RUN-5363: Enable Electron's unittests

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -45,9 +45,7 @@ launch_tests = function() {
 <p>It also has a ultra simple Node/Express server. Launch it in the Command line with 'node server' from the root directory.</p>
 
 <script type="text/javascript" charset="utf-8">
-const electron = require('electron');
-const commandLineArguments = electron.remote.app.getCommandLineArguments();
-if (commandLineArguments.includes('--enable-electron-apis')) {
+if (typeof process !== 'undefined' && process.argv.indexOf('--enable-electron-apis') !== -1) {
   document.write('Tests filter: <input type="text" id="tests_filter">');
   document.write('<button onclick="launch_tests();">Launch tests</a><br>');
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,11 +5,54 @@
     <title></title>
 </head>
 <body>
+
+<script type="text/javascript" charset="utf-8">
+launch_tests = function() {
+  const electron = require('electron');
+  const path = require('path');
+  const fs = require('fs');
+
+  // First check if nodejs modules required by tests has been fetched.
+  node_modules_dir = path.normalize(__dirname + '/../../../../../electron/spec/node_modules');
+  if (!fs.existsSync(node_modules_dir)) {
+    alert("Directory " + node_modules_dir + " does not exist.\n Run \"npm run test\" " +
+          "in directory electron to fetch needed nodejs modules.");
+    return;
+  }
+
+  let filter = document.getElementById("tests_filter").value;
+  index_file = path.normalize(__dirname + '/../../../../../electron/spec/static/index.html');
+  if (!fs.existsSync(index_file)) {
+    alert("File " + index_file + " does not exist.");
+    return;
+  }
+  let win = new electron.remote.BrowserWindow({
+      width: 800,
+      height: 600,
+      webPreferences: { additionalArguments: [ "--tests-filter=" + filter ] }
+  });
+  win.on('closed', () => {
+    win = null;
+  });
+  win.loadFile(index_file);
+}
+</script>
+
 <h2>Hello from OpenFin</h2>
 <p>This is a starting point for your OpenFin apps</p>
 <p>No frameworks, libraries or build systems.</p>
 <p>It has unit testing set up (using Karma/Jasmine).</p>
 <p>It also has a ultra simple Node/Express server. Launch it in the Command line with 'node server' from the root directory.</p>
+
+<script type="text/javascript" charset="utf-8">
+const electron = require('electron');
+const commandLineArguments = electron.remote.app.getCommandLineArguments();
+if (commandLineArguments.includes('--enable-electron-apis')) {
+  document.write('Tests filter: <input type="text" id="tests_filter">');
+  document.write('<button onclick="launch_tests();">Launch tests</a><br>');
+}
+</script>
+
 </body>
 </html>
 <script src="js/index.js"></script>


### PR DESCRIPTION
Goal of this task is to add possibility to launch Electron's unittests located in directory electron/spec on OpenFin's application. It will allow us to check if our chages break their apis or cause any regressions. These tests - in the future - could also be used as integration criteria for our tasks/bugfixes.